### PR TITLE
feat. github workflow to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: 🎉 Release Binary
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Check out code"
+        uses: actions/checkout@v3
+        with: 
+          fetch-depth: 0
+      
+      - name: "Set up Go"
+        uses: actions/setup-go@v4
+        with: 
+          go-version: 1.21.x
+      
+      - name: "Create release on GitHub"
+        uses: goreleaser/goreleaser-action@v4
+        with: 
+          args: "release --clean"
+          version: latest
+          workdir: .
+        env: 
+          GITHUB_TOKEN: "${{ secrets.RELEASE_TOKEN }}"


### PR DESCRIPTION
Hi, thank you for making good applications.

I got github workflow to build automatically on tag push.

you can generate github token, here.

https://github.com/settings/personal-access-tokens

<img width="777" height="683" alt="image" src="https://github.com/user-attachments/assets/b7686d6a-1680-4529-8adf-7a86023e57d2" />

and you can add that github token to repository, in repository secrets.

 https://github.com/ImAyrix/cut-cdn/settings/secrets/actions
RELEASE_TOKEN : (copied token)

then it will do it, itself.

have a good day!
- Woojae